### PR TITLE
Added '-help' and 'cheat' to the list of cheat usage arguments.

### DIFF
--- a/cheat
+++ b/cheat
@@ -16,7 +16,7 @@ cheatsheets = os.listdir(cheat_dir)
 cheatsheets.sort()
 
 # print help if requested
-if keyphrase in ['', 'help', '--help', '-h']:
+if keyphrase in ['', '-h', 'help', '-help', '--help', 'cheat']:
     print "Usage: cheat [keyphrase]\n"
     print "Available keyphrases:"
     print "\n".join(cheatsheets)


### PR DESCRIPTION
Added `-help` and `cheat` to the list of arguments that would show it's usage.
Felt that `cheat help` or `cheat --help` should have the same meaning as `cheat -help`.
Plus, what kind of a cheat sheet would this be if you couldn't use it on itself..
