### PR TITLE
Allow suffixes for cheat files (e.g. DataFrames.jl).

### DIFF
--- a/cheat
+++ b/cheat
@@ -23,7 +23,7 @@ def cheat_files(cheat_directories):
     cheats = {}
     for cheat_dir in reversed(cheat_directories):
         cheats.update(dict([ (cheat, cheat_dir)\
-                for cheat in os.listdir(cheat_dir) if '.' not in cheat ]))
+                for cheat in os.listdir(cheat_dir) if not cheat.startswith('.')]))
     return cheats
 
 def main():


### PR DESCRIPTION
There's no real reason not to allow suffixes for cheat sheets. Allowing `.` in the cheat file name lets us namespace cheats.

For example, I could create a cheat sheet `db.py` for Python and an equivalent `db.jl` for Julia, containing snippets for connecting to databases.
