### PR TITLE
Added in a create/edit option and stylistic change to output of a cheatsheet

### DIFF
--- a/cheat
+++ b/cheat
@@ -46,6 +46,30 @@ def cheat_files(cheat_directories):
                             and not cheat.startswith('__')]))
     return cheats
 
+def edit_cheatsheet(cheat, cheatsheets):
+    "Edit a pre-existing cheatsheet."
+    if cheat not in cheatsheets:
+        print 'No cheatsheet found for "%s"' % cheat
+        ans = raw_input('Create cheatsheet for "%s" (Y/N)? ' % cheat)
+        if ans.lower() in ['y', 'yes']:
+            create_cheatsheet(cheat, cheatsheets)
+        else:
+            exit()
+
+    subprocess.call([os.environ['EDITOR'],
+                    os.path.join(cheatsheets[cheat], cheat)])
+    exit()
+
+def create_cheatsheet(cheat, cheatsheets):
+    "Create a new cheatsheet."
+    if cheat in cheatsheets:
+        print 'Cheatsheet "%s" already exists' % cheat
+        exit()
+
+    import cheatsheets as cs
+    subprocess.call([os.environ['EDITOR'],
+                    os.path.join(cs.cheat_dir, cheat)])
+    exit()
 
 def main():
     # assemble a keyphrase out of all params passed to the script
@@ -70,24 +94,26 @@ def main():
                                 for key, value in cheatsheets.items()]))
         exit()
 
-    # if the user wants to edit a cheatsheet
-    if sys.argv[1].lower() in ['-e', '--edit']:
-        if len(sys.argv) < 2:
-            print 'Must provide a cheatsheet to edit'
-            exit()
-
-        cheatsheet = ' '.join(sys.argv[2:])
-
-        if cheatsheet not in cheatsheets:
-            print 'No cheatsheet found for %s.' % cheatsheet
-            exit()
-
+    # create/edit option
+    option = sys.argv[1].lower()
+    if option in ['-e', '--edit', '-c', '--create']:
+        # make sure EDITOR environment variable is set and that at least 3 arguments
+        # are given
         if 'EDITOR' not in os.environ:
-            print 'Must set your EDITOR environment variable to default editor path'
+            print('In order to use "create" or "edit" you must set your '
+                  'EDITOR environment variable to your favorite editor\'s path')
+            exit()
+        elif len(sys.argv) < 3:
+            print 'Must provide a cheatsheet to edit/create'
             exit()
 
-        subprocess.call([os.environ['EDITOR'],
-                        os.path.join(cheatsheets[cheatsheet], cheatsheet)])
+        # if the user wants to edit a cheatsheet
+        if option in ['-e', '--edit']:
+            edit_cheatsheet(' '.join(sys.argv[2:]), cheatsheets)
+
+        # if the user wants to create a cheatsheet
+        elif option in ['-c', '--create']:
+            create_cheatsheet(' '.join(sys.argv[2:]), cheatsheets)
 
     # print the cheatsheet if it exists
     if keyphrase in cheatsheets:


### PR DESCRIPTION
**I made two main changes:**
1. I made some stylistic changes when a cheatsheet is printed to stdout
2. I added in a create and edit option

**More detail on each change:**
1. This is my own personal preference so I'm not to sure if you would want to merge this in, but I personally find it extremely helpful. I noticed that every time I used `cheat` it took me a few seconds to realize where the top of the cheatsheet started because it visually blends into the command line prompt. With this stylistic change there is no ambiguity where the cheatsheet starts and ends. I won't go into detail what it looks like since the code is descriptive enough.
2. The code added for this isn't exactly the prettiest since you're not using `argparse` right now, so I am manually parsing all command line arguments. Basically now a user can edit and create a cheatsheet directly from `cheat`. Having to manually create the cheatsheet yourself is annoying, and hopefully this change fixes that. There are a few points I would like to point out though:
1. This requires the user to set their EDITOR environment variable
2. I'm not exactly sure where you're going with the default cheat directory, so right now I'm using the cheat directory defined by the cheatsheet import.
