### PR TITLE
To copy a key to a remote host on a non-standard port with non-standard ...

### DIFF
--- a/cheatsheets/ssh-copy-id
+++ b/cheatsheets/ssh-copy-id
@@ -3,3 +3,6 @@ ssh-copy-id username@host
 
 # To copy a key to a remote host on a non-standard port:
 ssh-copy-id username@host -p 2222
+
+# To copy a key to a remote host on a non-standard port with non-standard ssh key:
+ssh-copy-id ~/.ssh/otherkey "username@host -p 2222"


### PR DESCRIPTION
...ssh key

ssh-copy-id take two arguments max.
