### PR TITLE
Removed duplicate example, updated description of another example.

### DIFF
--- a/cheatsheets/grep
+++ b/cheatsheets/grep
@@ -1,6 +1,5 @@
 # Basic
 grep pattern file
 
-# Advanced
+# Recursively grep for string <pattern> in folder/
 grep -R pattern folder
-cat file | grep pattern


### PR DESCRIPTION
Removed cat file | grep pattern as cat file is unnecessary.  The command becomes 'grep pattern file' again - which is the same as the first example.

Updated #Advanced description to be more descriptive.
