### PR TITLE
-d now separates output using a newline

### DIFF
--- a/cheat
+++ b/cheat
@@ -143,7 +143,7 @@ def main():
 
     # list cheat directories and exit
     if option in ['-d', '--cheat_directories']:
-        print(' '.join(cheat_directories()))
+        print('\n'.join(cheat_directories()))
         exit()
 
     # print the cheatsheet if it exists


### PR DESCRIPTION
#53:

> I noticed that the -d option currently separates output directories using a space instead of a newline.

You are right, new line is better, and _cheat doesn't need to be updated (wierd)

> Forgive my lack of experience with zsh here, but do I need to add any further instructions (for using the new feature you implemented) to the README, or will the changes you made to the setup.py file take care of everything?

As far as I know `/usr/local/share/zsh/site-functions` should be in zsh's `$fpath` by default, but we can add a small notice, that in order for completions to work `/usr/local/share/zsh/site-functions` should be in `$fpath`, and small instruction how to add it to `$fpath`

Something like this:

```
~/.zshenv:
fpath=(/usr/local/share/zsh/site-functions $fpath)
```
