### PR TITLE
Allow subfolders in a cheats dir

### DIFF
--- a/cheat
+++ b/cheat
@@ -62,11 +62,19 @@ def cheat_directories():
 def cheat_files(cheat_directories):
     "Assembles a dictionary of cheatsheets found in the above directories."
     cheats = {}
-    for cheat_dir in reversed(cheat_directories):
-        cheats.update(dict([(cheat, cheat_dir)
-                            for cheat in os.listdir(cheat_dir)
-                            if not cheat.startswith('.')
-                            and not cheat.startswith('__')]))
+    queue = cheat_directories[:]
+    while queue:
+        cheat_dir = queue.pop()
+        for cheat in os.listdir(cheat_dir):
+            if not cheat.startswith('.') and not cheat.startswith('__'):
+                cheat_path = os.path.join(cheat_dir, cheat)
+                if os.path.isdir(cheat_path):
+                    # recurse subdirectory
+                    sub_dir = os.path.join(cheat_dir, cheat)
+                    queue.append(sub_dir)
+                else:
+                    cheats[cheat] = cheat_dir
+
     return cheats
 
 def edit_cheatsheet(cheat, cheatsheets):


### PR DESCRIPTION
This change allows you to have subfolders within your cheats directory. Here's some use cases:
- Sarah keeps a public github repo of cheats, but respects her friends Tom and Rachael, so she submodules their public cheat repos into hers. They appear in hear ~/.cheat folder as subfolders, and cheat recognises them automatically.
- James keeps a public repo of cheats, but also shares some for company specific code in a private company repo. He encourages all the company devs to check out the company cheat repo into their ~/.cheat folder, and so to help each other with common commands.

The core idea: having subfolders makes cheat much more sharing-friendly.
