### PR TITLE
EDITOR var with spaces throw exceptions

### DIFF
--- a/cheat
+++ b/cheat
@@ -69,7 +69,7 @@ class CheatSheets(object):
         if not self.dirs:
             error_msg = 'The {default} dir does not exist or the CHEATPATH var is not set.'
             print >> sys.stderr, error_msg.format(default=DEFAULT_CHEAT_DIR)
-            exit()
+            exit(1)
         self.sheets = self.__cheat_files()
 
     def __cheat_directories(self):
@@ -106,27 +106,38 @@ class CheatSheets(object):
         # Assert that the EDITOR environment variable is set and that at least 3
         # arguments have been given
         if 'EDITOR' not in os.environ:
-            print('In order to use "create" or "edit" you must set your '
-                  'EDITOR environment variable to your favorite editor\'s path')
-            exit()
+            print >> sys.stderr, ('In order to create/edit a cheatsheet you '
+                'must set your EDITOR environment variable to your favorite '
+                'editor\'s path.')
+            exit(1)
+        elif os.environ['EDITOR'] == "":
+            print >> sys.stderr, ('Your EDITOR environment variable is set '
+                'to nothing, in order to create/edit a cheatsheet your must '
+                'set it to a valid editor\'s path.')
+            exit(1)
         else:
             editor = os.environ['EDITOR'].split()
         # if the cheatsheet already exists, open it for editing
-        if cheat in sheets.sheets:
-            subprocess.call(editor + [os.path.join(self.sheets[cheat], cheat)])
+        try:
+            if cheat in sheets.sheets:
+                subprocess.call(editor + [os.path.join(self.sheets[cheat], cheat)])
 
-        # otherwise, create it
-        else:
-            import cheatsheets as cs
-            # Attempt to write the new cheatsheet to the user's ~/.cheat dir if it
-            # exists. If it does not exist, attempt to create it.
-            if os.access(DEFAULT_CHEAT_DIR, os.W_OK) or os.makedirs(DEFAULT_CHEAT_DIR):
-                subprocess.call(editor + [os.path.join(DEFAULT_CHEAT_DIR, cheat)])
-
-            # If the directory cannot be created, write to the python package
-            # directory, though that will likely require the use of sudo
+            # otherwise, create it
             else:
-                subprocess.call(editor + [os.path.join(cs.cheat_dir, cheat)])
+                import cheatsheets as cs
+                # Attempt to write the new cheatsheet to the user's ~/.cheat dir if it
+                # exists. If it does not exist, attempt to create it.
+                if os.access(DEFAULT_CHEAT_DIR, os.W_OK) or os.makedirs(DEFAULT_CHEAT_DIR):
+                    subprocess.call(editor + [os.path.join(DEFAULT_CHEAT_DIR, cheat)])
+
+                # If the directory cannot be created, write to the python package
+                # directory, though that will likely require the use of sudo
+                else:
+                    subprocess.call(editor + [os.path.join(cs.cheat_dir, cheat)])
+        except OSError, e:
+            print >> sys.stderr, ("Could not launch `%s` as your editor : %s"
+                                  % (editor[0], e.strerror))
+            exit(1)
 
     def list(self):
         """Lists the cheatsheets that are currently available"""


### PR DESCRIPTION
This is a pull request to correct issue #99

EDITOR variables containing options like mine 'emacs -nw -no-init-file --quick' just made `Popen` throw back an exception, when first argument of `Popen` not set to an absolute path, `Popen` will search 1st args in $PATH, but 'emacs -nw -no-init-file --quick' is not a binary that could be found in $PATH. The fix was just to split the EDITOR variable to have binary and args in a list like Popen wants it.

Just added some check like if EDITOR is set to none + Try catch just in case EDITOR is not found in PATH (like not instaled or so).

PS : Sorry for the dirty commit message, just had a problem with my git when merging upstream with master when the last working branch was OOP.

PPS : Added return value when failed + print to stderr
