### PR TITLE
Adding two invaluable commands to tmux cheatsheet

### DIFF
--- a/cheatsheets/tmux
+++ b/cheatsheets/tmux
@@ -7,6 +7,9 @@ Ctrl-b d
 # Restore tmux session:
 tmux attach
 
+# Detach an already attached session (great if you are moving devices with different screen resolutions)
+tmux attach -d 
+
 # Display session:
 tmux ls
 
@@ -19,6 +22,9 @@ Ctrl-b ?
 
 # Scroll in window:
 Ctrl-b PageUp/PageDown
+
+# Reload configuation file
+Ctrl-b : source-file /path/to/file
 
 # Window management
 # =================


### PR DESCRIPTION
- Detaching an already attached tmux session - great for when you are moving from a phone for example to a laptop and want to utilise the whole real estate you have.
- Reloading the configuration file on the fly by using the colon menu
