### PR TITLE
Fix geteuid not existing on Windows

### DIFF
--- a/cheat/sheets.py
+++ b/cheat/sheets.py
@@ -9,7 +9,7 @@ def default_path():
     # the default path becomes confused when cheat is run as root, so fail
     # under those circumstances. (There is no good reason to need to run cheat
     # as root.)
-    if os.geteuid() == 0:
+    if os.name != 'nt' and os.geteuid() == 0:
         die('Please do not run this application as root.');
 
     # determine the default cheatsheet dir


### PR DESCRIPTION
Previously this would not run on Windows as `os.geteuid` does not exist on Windows.

I think that using the check `"geteuid" in dir(os)` is superior though.
