### PR TITLE
fix setup for Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,15 @@
 from distutils.core import setup
 import os
 
+data = [
+       ('/usr/share/zsh/site-functions', ['cheat/autocompletion/_cheat.zsh']),
+       ('/etc/bash_completion.d'       , ['cheat/autocompletion/cheat.bash']),
+       ('/usr/share/fish/completions'  , ['cheat/autocompletion/cheat.fish'])
+       ]
+
+if os.name == 'nt':
+    data = []
+
 setup(
     name         = 'cheat',
     version      = '2.0.1',
@@ -21,11 +30,7 @@ setup(
         'cheat.cheatsheets': [f for f in os.listdir('cheat/cheatsheets') if '.' not in f]
     },
     scripts      = ['bin/cheat'],
-    data_files   = [
-        ('/usr/share/zsh/site-functions', ['cheat/autocompletion/_cheat.zsh']),
-        ('/etc/bash_completion.d'       , ['cheat/autocompletion/cheat.bash']),
-        ('/usr/share/fish/completions'  , ['cheat/autocompletion/cheat.fish'])
-    ],
+    data_files   = data,
     install_requires = [
         'docopt >= 0.6.1',
         'pygments >= 1.6.0',


### PR DESCRIPTION
If you run the current `setup.py` file on Windows you get this error

```
Traceback (most recent call last):
  File "setup.py", line 31, in <module>
    'pygments >= 1.6.0',
  File "c:\Python27\lib\distutils\core.py", line 152, in setup
    dist.run_commands()
  File "c:\Python27\lib\distutils\dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "c:\Python27\lib\distutils\dist.py", line 972, in run_command
    cmd_obj.run()
  File "c:\Python27\lib\distutils\command\install.py", line 575, in run
    self.run_command(cmd_name)
  File "c:\Python27\lib\distutils\cmd.py", line 326, in run_command
    self.distribution.run_command(command)
  File "c:\Python27\lib\distutils\dist.py", line 972, in run_command
    cmd_obj.run()
  File "c:\Python27\lib\distutils\command\install_data.py", line 58, in run
    dir = convert_path(f[0])
  File "c:\Python27\lib\distutils\util.py", line 124, in convert_path
    raise ValueError, "path '%s' cannot be absolute" % pathname
ValueError: path '/usr/share/zsh/site-functions' cannot be absolute
```

This change fixes this issue.
I check for the `os.name` since Cygwin can still support those absolute paths. (on Cygwin `os.name` is `posix`)
