### PR TITLE
use the systems data directory as default_path

### DIFF
--- a/cheat/sheets.py
+++ b/cheat/sheets.py
@@ -1,5 +1,6 @@
 from cheat import cheatsheets
 from cheat.utils import *
+from xdg.BaseDirectory import save_data_path
 import os
 
 # @kludge: it breaks the functional paradigm to a degree, but declaring this
@@ -19,7 +20,16 @@ def default_path():
         die('Please do not run this application as root.');
 
     # determine the default cheatsheet dir
-    default_sheets_dir = os.environ.get('DEFAULT_CHEAT_DIR') or os.path.join(os.path.expanduser('~'), '.cheat')
+    if os.environ.get('DEFAULT_CHEAT_DIR'):
+        # if the environment variable is set, use it in any case
+        default_sheets_dir = os.environ.get('DEFAULT_CHEAT_DIR')
+    else:
+        # use `.cheat` in the users HOME *if* it exists
+        default_sheets_dir = os.path.join(os.path.expanduser('~'), '.cheat')
+        if not os.path.isdir(default_sheets_dir):
+            # or else use `cheat` in the systems prefered data-directory
+            # the directory is created if it doesn't already exists
+            default_sheets_dir = save_data_path('cheat')
 
     # create the DEFAULT_CHEAT_DIR if it does not exist
     if not os.path.isdir(default_sheets_dir):


### PR DESCRIPTION
Most operating systems have a **default path**, where programs can store their data, e.g. in Linux this is `~/.local/share/` for data and `~/.config/` for configuration files. It would be nice if cheat supports this, instead of using the `.cheat` directory.

I think we should look at three cases:
1. If the environment variable is set, use it:
   
   If the user sets it, he or she probably done it for a reasons, so use it in any case.
2. If a `.cheat` directory exists in the home directory use it:
   
   Of course for backward compatible reasons and as an easy way for people who like this 
   method better than 3.
3. If none of the above, use the systems default dir:
   
   This is imo the "cleanest" solution and should be the default.
