### PR TITLE
Issue #172

### DIFF
--- a/cheat/sheets.py
+++ b/cheat/sheets.py
@@ -12,12 +12,6 @@ cheats = {}
 def default_path():
     """ Returns the default cheatsheet path """
 
-    # the default path becomes confused when cheat is run as root, so fail
-    # under those circumstances. (There is no good reason to need to run cheat
-    # as root.)
-    if os.name != 'nt' and os.geteuid() == 0:
-        die('Please do not run this application as root.');
-
     # determine the default cheatsheet dir
     default_sheets_dir = os.environ.get('DEFAULT_CHEAT_DIR') or os.path.join(os.path.expanduser('~'), '.cheat')
 


### PR DESCRIPTION
Previously, `cheat` would exit if run by `root`. The rationale was:

If `cheat` was run by an unprivileged user (`chris`, for example), the
`$DEFAULT_CHEAT_DIR` would default to `/home/chris/.cheat`. If cheat was
run via `sudo`, however, the `$DEFAULT_CHEAT_DIR` would suddenly be
`/root/.cheat`.

Presuming that those individual user cheat dirs actually contained cheat
sheets, this could cause confusion, because cheat sheets accessible to
one user (`chris`) would not be accessible to the other (`root`). Thus,
cheatsheets would appear and disappear, depending on which user was
running `cheat`. (This would only be an issue, of course, for cheat
sheets that existed within the respective users' cheat dirs. System-wide
cheat sheets would be unaffected.)

`cheat` was thus programmed to gracefully fail when run as `root` to
prevent that possible confusion.

However, I'm backing away from that reasoning, because:
1. It's causing a headache for real users who'd like to run `cheat` as
   root
2. Other venerable programs (`vim`, etc.) suffer from the same problem,
   but nobody seems to mind enough to do anything about it. Thus, I suppose
   the laissez-faire approach is essentially the sanctioned "solution" to
   this problem.
3. Users sufficently troubled by this confusion may rememdy the problem
   manually by setting environment variables (`$DEFAULT_CHEAT_DIR`, etc.)

Thus, `cheat` no longer complains if run by `root`.

Version-bumped to 2.1.0.
