### PR TITLE
link changed, added details

### DIFF
--- a/cheat/cheatsheets/youtube-dl
+++ b/cheat/cheatsheets/youtube-dl
@@ -19,5 +19,5 @@ youtube-dl -s example.com/watch?v=id
 # To download audio in mp3 format with best quality available
 youtube-dl --extract-audio --audio-format mp3 --audio-quality 0 example.com/watch?v=id
 
-# For all video formats see
-# http://en.wikipedia.org/wiki/YouTube#Quality_and_codecs
+# For all video formats see link below (unfold "Comparison of YouTube media encoding options")
+# https://en.wikipedia.org/w/index.php?title=YouTube&oldid=723160791#Quality_and_formats


### PR DESCRIPTION
The table isn't available any more in the recent wiki page. The new link uses the old version of wikipedia. In my browser I have to "unhide" the box.