### PR TITLE
ssh: Improve SOCKS command

### DIFF
--- a/cheat/cheatsheets/ssh
+++ b/cheat/cheatsheets/ssh
@@ -21,7 +21,7 @@ ssh -f -L 8080:remote.example.com:5000 user@personal.server.com -N
 ssh -X -t user@example.com 'chromium-browser'
 
 # To create a SOCKS proxy on localhost and port 9999
-ssh -D 9999 user@example.com
+ssh -qND 9999 user@example.com
 
 # To tunnel an ssh session over the SOCKS proxy on localhost and port 9999
 ssh -o "ProxyCommand nc -x 127.0.0.1:9999 -X 4 %h %p" username@example2.com


### PR DESCRIPTION
This doesn't give an SSH shell, but just forwards the ports - which is what one usually requires when setting up a SOCKS proxy.

The -q is to suppress messages etc.