### PR TITLE
Support for highlighting based on filename

### DIFF
--- a/bin/cheat
+++ b/bin/cheat
@@ -102,4 +102,4 @@ if __name__ == '__main__':
 
     # print the cheatsheet
     else:
-        print(colorize.syntax(sheet.read(options['<cheatsheet>'])), end="")
+        print(colorize.syntax(sheet.read(options['<cheatsheet>']),options['<cheatsheet>']), end="")

--- a/cheat/colorize.py
+++ b/cheat/colorize.py
@@ -26,7 +26,7 @@ class Colorize:
         return haystack.replace(needle,
                                 colored(needle, self._config.cheat_highlight))
 
-    def syntax(self, sheet_content):
+    def syntax(self, sheet_content, *sheet_filename):
         """ Applies syntax highlighting """
 
         # only colorize if cheat_colors is true, and stdout is a tty
@@ -41,6 +41,7 @@ class Colorize:
         try:
             from pygments import highlight
             from pygments.lexers import get_lexer_by_name
+            from pygments.lexers import get_lexer_for_filename
             from pygments.formatters import TerminalFormatter
 
         # if the import fails, return uncolored text
@@ -50,6 +51,13 @@ class Colorize:
         # otherwise, attempt to colorize
         first_line = sheet_content.splitlines()[0]
         lexer = get_lexer_by_name('bash')
+
+        # apply syntax-highlighting based on filename
+        if sheet_filename:
+            try:
+                lexer = get_lexer_for_filename(sheet_filename[0])
+            except Exception:
+                pass
 
         # apply syntax-highlighting if the first line is a code-fence
         if first_line.startswith('```'):


### PR DESCRIPTION
Syntax highlighting can now be determined by filename of the cheat sheet; e.g. a cheat sheet named "regex.py" would receive python syntax highlighting, and a cheat sheet named "regex.bash" would receive bash syntax highlighting.

Workaround right now: You can add syntax highlighting by adding a code fence around a file like `` ```python ``` ``.