### PR TITLE
Added pager support. The pager 'less' has highlighting.

### DIFF
--- a/bin/cheat
+++ b/bin/cheat
@@ -7,6 +7,8 @@ Create and view cheatsheets on the command line.
 Usage:
   cheat <cheatsheet>
   cheat -e <cheatsheet>
+  cheat -p <cheatsheet>
+  cheat -ps <keyword>
   cheat -s <keyword>
   cheat -l
   cheat -d
@@ -18,6 +20,7 @@ Options:
   -l --list         List cheatsheets
   -s --search       Search cheatsheets for <keyword>
   -v --version      Print the version number
+  -p --pager        Pages through output instead of going directly to terminal
 
 Examples:
 
@@ -38,6 +41,7 @@ Examples:
 from __future__ import print_function
 from cheat.colorize import Colorize
 from cheat.configuration import Configuration
+from cheat.output import outPager
 from cheat.sheet import Sheet
 from cheat.sheets import Sheets
 from cheat.utils import Utils
@@ -95,6 +99,13 @@ if __name__ == '__main__':
     # create/edit cheatsheet
     elif options['--edit']:
         sheet.edit(options['<cheatsheet>'])
+
+    # use pager with other options
+    elif options['--pager']:
+        if options['--search']:
+            outPager(sheets.search(options['<keyword>']), colorize)
+        else:
+            outPager(sheet.read(options['<cheatsheet>']), colorize)
 
     # search among the cheatsheets
     elif options['--search']:

--- a/cheat/output.py
+++ b/cheat/output.py
@@ -1,0 +1,15 @@
+def is_tool(name):
+    """Check whether `name` is on PATH."""
+
+    from distutils.spawn import find_executable
+
+    return find_executable(name) is not None
+
+def outPager(sheet_content,colorize):
+    """Runs pydoc.pager(sheet_content). If less is on PATH, colorizes output"""
+    if is_tool('less'):
+        from pydoc import pipepager
+        pipepager(colorize.syntax(sheet_content),'less -R')
+    else:
+        from pydoc import pager
+        pager(sheet_content)


### PR DESCRIPTION
For particularly lengthy query results, you can now use:
cheat -p <cheatsheet>
cheat -ps <keyword>
to stream the resulting text output to a paging program. If 'less' is in your PATH, it will show syntax highlighting.

While you can pipe output to pagers NOW, you can't get syntax highlighting by doing so, since you actually need to use special escape characters to control terminal output which you can't get using just print().