### PR TITLE
Fix typo, action (-I -> -l)

### DIFF
--- a/cheat/cheatsheets/dpkg
+++ b/cheat/cheatsheets/dpkg
@@ -5,7 +5,7 @@ dpkg -i test.deb
 dpkg -P test.deb
 
 # List all installed packages with versions and details
-dpkg -I
+dpkg -l
 
 # Find out if a Debian package is installed or not
 dpkg -s test.deb | grep Status


### PR DESCRIPTION
dpkg -I (capital i) is for showing information about a package.
dpkg -l (lowercase l) is for listing packages matching given pattern.

So, here is a fix for the typo.