### PR TITLE
fixed listing empty folder of cheatsheets

### DIFF
--- a/cheat/sheets.py
+++ b/cheat/sheets.py
@@ -56,7 +56,7 @@ class Sheets:
     def list(self):
         """ Lists the available cheatsheets """
         sheet_list = ''
-        pad_length = max([len(x) for x in self.get().keys()]) + 4
+        pad_length = max([len(x) for x in self.get().keys()], default=0) + 4
         for sheet in sorted(self.get().items()):
             sheet_list += sheet[0].ljust(pad_length) + sheet[1] + "\n"
         return sheet_list


### PR DESCRIPTION
When setting `CHEAT_PATH` to `""`, in order to only make use of `CHEAT_USER_DIR`, it initially happens that there are no cheatsheets.

Hence, `cheat -l` crashes because the `max()` function operates on an empty list. I fixed the crash by introducing the `default` parameter for `max()`.