### PR TITLE
print instructive message instead of error message after `cheat -l` when no cheetsheet's there

### DIFF
--- a/cheat/sheets.py
+++ b/cheat/sheets.py
@@ -55,7 +55,7 @@ class Sheets:
 
     def list(self):
         """ Lists the available cheatsheets """
-        if not len(self.get()):
+        if not self.get():
             return 'No cheatsheets yet. Create and edit by `cheat -e <your-cheatsheet>`.'
         sheet_list = ''
         pad_length = max([len(x) for x in self.get().keys()]) + 4

--- a/cheat/sheets.py
+++ b/cheat/sheets.py
@@ -55,6 +55,8 @@ class Sheets:
 
     def list(self):
         """ Lists the available cheatsheets """
+        if not len(self.get()):
+            return 'No cheatsheets yet. Create and edit by `cheat -e <your-cheatsheet>`.'
         sheet_list = ''
         pad_length = max([len(x) for x in self.get().keys()]) + 4
         for sheet in sorted(self.get().items()):


### PR DESCRIPTION
Hi.

Currently, `cheat -l` prints error message like below when there's no cheetsheets. (#449)
```bash
ValueError: max() arg is an empty sequence
```
This is thrown while calculating `pad_length` in function `list` in cheat/sheets.py

This PR prints instructive message like below instead of the error message.
```bash
No cheatsheets yet. Create and edit by `cheat -e <your-cheatsheet>`.
```

There is a similar PR(#447) that fixes the same problem (#449), but main approach is different. 
For understanding the difference before deciding what to merge, please read my comment(s) on #447.

Thanks. 