### PR TITLE
Add cheatsheet for `z`

### DIFF
--- a/cheat/cheatsheets/z
+++ b/cheat/cheatsheets/z
@@ -1,0 +1,14 @@
+# To `cd` to most frecent dir matching `foo`
+z foo
+
+# To `cd` to most frecent dir matching `foo`, then `bar`
+z foo bar
+
+# To `cd` to highest ranked dir matching `foo`
+z -r foo
+
+# To `cd` to most recently accessed dir matching `foo`
+z -t foo
+
+# To list all dirs matching `foo` - By frecency
+z -l foo


### PR DESCRIPTION
As mentioned in [my previous PR](https://github.com/cheat/cheat/pull/402), I replaced my use of `scd` with `z`. `z` has become the one command I use most, period.

The term 'frecency' is not a typo (I almost submitted a PR to their repo before realizing it was intended 😁). 
From their README: 
```
   Frecency:
       Frecency is a portmanteau of 'recent' and 'frequency'. It is a weighted
       rank  that depends on how often and how recently something occurred. As
       far as I know, Mozilla came up with the term.

       To z, a directory that has low ranking but has been  accessed  recently
       will  quickly  have  higher rank than a directory accessed frequently a
       long time ago.

       Frecency is determined at runtime.
```