### PR TITLE
Properly trim path separators on Windows

### DIFF
--- a/internal/sheets/load.go
+++ b/internal/sheets/load.go
@@ -45,7 +45,7 @@ func Load(cheatpaths []cp.Cheatpath) ([]map[string]sheet.Sheet, error) {
 				// accessed. Eg: `cheat tar` - `tar` is the title)
 				title := strings.TrimPrefix(
 					strings.TrimPrefix(path, cheatpath.Path),
-					"/",
+					string(os.PathSeparator),
 				)
 
 				// ignore hidden files and directories. Otherwise, we'll likely load


### PR DESCRIPTION
This PR attempts to fix the cheatsheets titles on Windows. An example of this issue can be found in [this](https://github.com/cheat/cheat/issues/493#issuecomment-550150843) comment:

cheat -l

```
\7z            C:\Users\Moses\scripts\cheatsheets-master\7z            compression,personal
\ab            C:\Users\Moses\scripts\cheatsheets-master\ab            personal
\alias         C:\Users\Moses\scripts\cheatsheets-master\alias         personal
\ansi          C:\Users\Moses\scripts\cheatsheets-master\ansi          personal
\apk           C:\Users\Moses\scripts\cheatsheets-master\apk           packaging,personal
\apparmor      C:\Users\Moses\scripts\cheatsheets-master\apparmor      personal
\apt           C:\Users\Moses\scripts\cheatsheets-master\apt           packaging,personal
\apt-cache     C:\Users\Moses\scripts\cheatsheets-master\apt-cache     packaging,personal
\apt-get       C:\Users\Moses\scripts\cheatsheets-master\apt-get       packaging,personal
\aptitude      C:\Users\Moses\scripts\cheatsheets-master\aptitude      packaging,personal
\aria2c        C:\Users\Moses\scripts\cheatsheets-master\aria2c        personal
\asciiart      C:\Users\Moses\scripts\cheatsheets-master\asciiart      personal
\asterisk      C:\Users\Moses\scripts\cheatsheets-master\asterisk      personal
\at            C:\Users\Moses\scripts\cheatsheets-master\at            personal
\awk           C:\Users\Moses\scripts\cheatsheets-master\awk           personal
\bash          C:\Users\Moses\scripts\cheatsheets-master\bash          personal
...
```
