### PR TITLE
Better native paths support

### DIFF
--- a/cmd/cheat/cmd_init.go
+++ b/cmd/cheat/cmd_init.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"runtime"
 	"text/template"
 
 	"github.com/cheat/cheat/internal/config"
@@ -12,7 +11,7 @@ import (
 // cmdInit displays an example config file.
 func cmdInit() {
 
-	prefFolderPath, err := config.PreferredFolderPath(runtime.GOOS)
+	prefFolderPath, err := config.PreferredFolderPath()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "could not locate config folder path: ", err)
 		os.Exit(1)
@@ -30,7 +29,7 @@ func cmdInit() {
 	t := template.Must(template.New("configs").Parse(configs()))
 	err = t.Execute(os.Stdout, values)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "executing template:: ", err)
+		fmt.Fprintln(os.Stderr, "could not execute template configs: ", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/cheat/cmd_init.go
+++ b/cmd/cheat/cmd_init.go
@@ -2,9 +2,35 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"runtime"
+	"text/template"
+
+	"github.com/cheat/cheat/internal/config"
 )
 
 // cmdInit displays an example config file.
 func cmdInit() {
-	fmt.Println(configs())
+
+	prefFolderPath, err := config.PreferredFolderPath(runtime.GOOS)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "could not locate config folder path: ", err)
+		os.Exit(1)
+	}
+
+	if prefFolderPath != "" {
+		prefFolderPath += string(os.PathSeparator)
+	}
+
+	type ConfigValues struct {
+		CheatsheetsBasePath string
+	}
+
+	values := ConfigValues{prefFolderPath}
+	t := template.Must(template.New("configs").Parse(configs()))
+	err = t.Execute(os.Stdout, values)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "executing template:: ", err)
+		os.Exit(1)
+	}
 }

--- a/cmd/cheat/docopt.txt
+++ b/cmd/cheat/docopt.txt
@@ -18,7 +18,7 @@ Options:
 Examples:
 
   To initialize a config file:
-    mkdir -p ~/.config/cheat && cheat --init > ~/.config/cheat/conf.yml
+    {{.InitConfigCommand}}
 
   To view the tar cheatsheet:
     cheat tar
@@ -26,8 +26,8 @@ Examples:
   To edit (or create) the foo cheatsheet:
     cheat -e foo
 
-  To edit (or create) the foo/bar cheatsheet on the "work" cheatpath:
-    cheat -p work -e foo/bar
+  To edit (or create) the foo{{.PathSeparator}}bar cheatsheet on the "work" cheatpath:
+    cheat -p work -e foo{{.PathSeparator}}bar
 
   To view all cheatsheet directories:
     cheat -d
@@ -47,5 +47,5 @@ Examples:
   To search (by regex) for cheatsheets that contain an IP address:
     cheat -c -r -s '(?:[0-9]{1,3}\.){3}[0-9]{1,3}'
 
-  To remove (delete) the foo/bar cheatsheet:
-    cheat --rm foo/bar
+  To remove (delete) the foo{{.PathSeparator}}bar cheatsheet:
+    cheat --rm foo{{.PathSeparator}}bar

--- a/cmd/cheat/main.go
+++ b/cmd/cheat/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 	"text/template"
 
 	"github.com/docopt/docopt-go"
@@ -141,7 +142,14 @@ func generateInitConfigCommand() (string, error) {
 
 	switch runtime.GOOS {
 	case "windows":
-		return fmt.Sprintf("md \"%s\" | Out-Null; cheat.exe --init > \"%s\"", prefFolderPath, prefConfigPath), nil
+		var collapse = func(path string) string {
+			var appDataPath = os.Getenv("APPDATA")
+			if strings.HasPrefix(path, appDataPath) {
+				path = "$env:APPDATA" + path[len(appDataPath):]
+			}
+			return path
+		}
+		return fmt.Sprintf("md -Force \"%s\" | Out-Null; cheat.exe --init > \"%s\"", collapse(prefFolderPath), collapse(prefConfigPath)), nil
 	default:
 		return fmt.Sprintf("mkdir -p %s && cheat --init > %s", prefFolderPath, prefConfigPath), nil
 	}

--- a/cmd/cheat/main.go
+++ b/cmd/cheat/main.go
@@ -149,8 +149,16 @@ func generateInitConfigCommand() (string, error) {
 			}
 			return path
 		}
-		return fmt.Sprintf("md -Force \"%s\" | Out-Null; cheat.exe --init > \"%s\"", collapse(prefFolderPath), collapse(prefConfigPath)), nil
-	default:
-		return fmt.Sprintf("mkdir -p %s && cheat --init > %s", prefFolderPath, prefConfigPath), nil
+
+		return fmt.Sprintf("md -Force \"%s\" | Out-Null; cheat.exe --init > \"%s\"",
+			collapse(prefFolderPath), collapse(prefConfigPath)), nil
+
+	default: /* posix */
+		var escape = func(path string) string {
+			return strings.ReplaceAll(path, " ", "\\ ")
+		}
+
+		return fmt.Sprintf("mkdir -p %s && cheat --init > %s",
+			escape(prefFolderPath), escape(prefConfigPath)), nil
 	}
 }

--- a/cmd/cheat/str_config.go
+++ b/cmd/cheat/str_config.go
@@ -44,21 +44,21 @@ cheatpaths:
   # Note that the paths and tags listed below are just examples. You may freely
   # change them to suit your needs.
   - name: community
-    path: ~/.dotfiles/cheat/community
+    path: {{.CheatsheetsBasePath}}community
     tags: [ community ]
     readonly: true
 
   # Maybe your company or department maintains a repository of cheatsheets as
   # well. It's probably sensible to list those second.
   - name: work
-    path: ~/.dotfiles/cheat/work
+    path: {{.CheatsheetsBasePath}}work
     tags: [ work ]
     readonly: false
 
   # If you have personalized cheatsheets, list them last. They will take
   # precedence over the more global cheatsheets.
   - name: personal
-    path: ~/.dotfiles/cheat/personal
+    path: {{.CheatsheetsBasePath}}personal
     tags: [ personal ]
     readonly: false
 `)

--- a/cmd/cheat/str_usage.go
+++ b/cmd/cheat/str_usage.go
@@ -27,7 +27,7 @@ Options:
 Examples:
 
   To initialize a config file:
-    mkdir -p ~/.config/cheat && cheat --init > ~/.config/cheat/conf.yml
+    {{.InitConfigCommand}}
 
   To view the tar cheatsheet:
     cheat tar
@@ -35,8 +35,8 @@ Examples:
   To edit (or create) the foo cheatsheet:
     cheat -e foo
 
-  To edit (or create) the foo/bar cheatsheet on the "work" cheatpath:
-    cheat -p work -e foo/bar
+  To edit (or create) the foo{{.PathSeparator}}bar cheatsheet on the "work" cheatpath:
+    cheat -p work -e foo{{.PathSeparator}}bar
 
   To view all cheatsheet directories:
     cheat -d
@@ -56,7 +56,7 @@ Examples:
   To search (by regex) for cheatsheets that contain an IP address:
     cheat -c -r -s '(?:[0-9]{1,3}\.){3}[0-9]{1,3}'
 
-  To remove (delete) the foo/bar cheatsheet:
-    cheat --rm foo/bar
+  To remove (delete) the foo{{.PathSeparator}}bar cheatsheet:
+    cheat --rm foo{{.PathSeparator}}bar
 `)
 }

--- a/configs/conf.yml
+++ b/configs/conf.yml
@@ -35,20 +35,20 @@ cheatpaths:
   # Note that the paths and tags listed below are just examples. You may freely
   # change them to suit your needs.
   - name: community
-    path: ~/.dotfiles/cheat/community
+    path: {{.CheatsheetsBasePath}}community
     tags: [ community ]
     readonly: true
 
   # Maybe your company or department maintains a repository of cheatsheets as
   # well. It's probably sensible to list those second.
   - name: work
-    path: ~/.dotfiles/cheat/work
+    path: {{.CheatsheetsBasePath}}work
     tags: [ work ]
     readonly: false
 
   # If you have personalized cheatsheets, list them last. They will take
   # precedence over the more global cheatsheets.
   - name: personal
-    path: ~/.dotfiles/cheat/personal
+    path: {{.CheatsheetsBasePath}}personal
     tags: [ personal ]
     readonly: false

--- a/internal/config/path.go
+++ b/internal/config/path.go
@@ -90,7 +90,7 @@ func Path() (string, error) {
 
 	case "darwin":
 
-		homePath = os.Getenv("HOME")
+		homePath := os.Getenv("HOME")
 
 		// macOS config paths
 		paths = []string{
@@ -104,7 +104,7 @@ func Path() (string, error) {
 
 	case "linux":
 
-		homePath = os.Getenv("HOME")
+		homePath := os.Getenv("HOME")
 
 		// Linux config paths
 		paths = []string{

--- a/internal/config/path.go
+++ b/internal/config/path.go
@@ -2,9 +2,9 @@ package config
 
 import (
 	"fmt"
-	"runtime"
 	"os"
 	"path"
+	"runtime"
 	"strings"
 
 	"github.com/mitchellh/go-homedir"
@@ -24,11 +24,7 @@ func PreferredFolderPath() (string, error) {
 	case "darwin":
 
 		// macOS default folder path
-		xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
-		if xdgConfigHome != "" {
-			return path.Join(xdgConfigHome, configFolder), nil
-		}
-		return path.Join("~/.config", configFolder), nil
+		return path.Join("~/Library/Application Support", configFolder), nil
 
 	case "linux":
 
@@ -94,21 +90,28 @@ func Path() (string, error) {
 
 	case "darwin":
 
+		homePath = os.Getenv("HOME")
+
 		// macOS config paths
 		paths = []string{
+			path.Join(homePath, "Library/Application Support", configFolder, configFileName),
 			path.Join(os.Getenv("XDG_CONFIG_HOME"), configFolder, configFileName),
-			path.Join(os.Getenv("HOME"), ".config", configFolder, configFileName),
-			path.Join(os.Getenv("HOME"), "."+configFolder, configFileName),
+			path.Join(homePath, ".config", configFolder, configFileName),
+			path.Join(homePath, "."+configFolder, configFileName),
+			path.Join("/Library/Application Support", configFolder, configFileName),
+			path.Join("/etc", configFolder, configFileName),
 		}
 
 	case "linux":
 
+		homePath = os.Getenv("HOME")
+
 		// Linux config paths
 		paths = []string{
 			path.Join(os.Getenv("XDG_CONFIG_HOME"), configFolder, configFileName),
-			path.Join(os.Getenv("HOME"), ".config", configFolder, configFileName),
-			path.Join(os.Getenv("HOME"), "."+configFolder, configFileName),
-			path.Join("/etc", "."+configFolder, configFileName),
+			path.Join(homePath, ".config", configFolder, configFileName),
+			path.Join(homePath, "."+configFolder, configFileName),
+			path.Join("/etc", configFolder, configFileName),
 		}
 
 	case "windows":
@@ -145,7 +148,6 @@ func Path() (string, error) {
 func getExpandedEnv(envVar string) (string, error) {
 
 	value := os.Getenv(envVar)
-
 	if value != "" {
 
 		// expand environment variable

--- a/internal/config/path.go
+++ b/internal/config/path.go
@@ -27,9 +27,8 @@ func PreferredFolderPath() (string, error) {
 		xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
 		if xdgConfigHome != "" {
 			return path.Join(xdgConfigHome, configFolder), nil
-		} else {
-			return path.Join("~/.config", configFolder), nil
 		}
+		return path.Join("~/.config", configFolder), nil
 
 	case "linux":
 
@@ -37,9 +36,8 @@ func PreferredFolderPath() (string, error) {
 		xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
 		if xdgConfigHome != "" {
 			return path.Join(xdgConfigHome, configFolder), nil
-		} else {
-			return path.Join("~/.config", configFolder), nil
 		}
+		return path.Join("~/.config", configFolder), nil
 
 	case "windows":
 

--- a/internal/config/path.go
+++ b/internal/config/path.go
@@ -19,6 +19,12 @@ const (
 // PreferredFolderPath returns the default cheat folder path
 func PreferredFolderPath() (string, error) {
 
+	// if CHEAT_CONFIG_PATH is set, honor it
+	envFilePath := os.Getenv(configFilePathEnvVar)
+	if envFilePath != "" {
+		return filepath.Dir(envFilePath), nil
+	}
+
 	switch runtime.GOOS {
 
 	case "darwin":
@@ -51,7 +57,7 @@ func PreferredFolderPath() (string, error) {
 // PreferredConfigPath returns the default config file path
 func PreferredConfigPath() (string, error) {
 
-	// if CHEAT_CONFIG_PATH is set, return it
+	// if CHEAT_CONFIG_PATH is set, honor it
 	envFilePath := os.Getenv(configFilePathEnvVar)
 	if envFilePath != "" {
 		return envFilePath, nil

--- a/internal/config/path.go
+++ b/internal/config/path.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"runtime"
-	"strings"
 
 	"github.com/mitchellh/go-homedir"
 )
@@ -38,8 +38,7 @@ func PreferredFolderPath() (string, error) {
 	case "windows":
 
 		// Windows default folder path
-		folderPath := path.Join(os.Getenv("APPDATA"), configFolder)
-		return strings.ReplaceAll(folderPath, "/", "\\"), nil
+		return filepath.Clean(path.Join(os.Getenv("APPDATA"), configFolder)), nil
 
 	default:
 
@@ -63,12 +62,7 @@ func PreferredConfigPath() (string, error) {
 		return "", err
 	}
 
-	configPath := path.Join(configFolder, configFileName)
-	if runtime.GOOS == "windows" {
-		configPath = strings.ReplaceAll(configPath, "/", "\\")
-	}
-
-	return configPath, nil
+	return filepath.Clean(path.Join(configFolder, configFileName)), nil
 }
 
 // Path returns the config file path
@@ -118,12 +112,8 @@ func Path() (string, error) {
 
 		// Windows config paths
 		paths = []string{
-			path.Join(os.Getenv("APPDATA"), configFolder, configFileName),
-			path.Join(os.Getenv("PROGRAMDATA"), configFolder, configFileName),
-		}
-
-		for i, p := range paths {
-			paths[i] = strings.ReplaceAll(p, "/", "\\")
+			filepath.Clean(path.Join(os.Getenv("APPDATA"), configFolder, configFileName)),
+			filepath.Clean(path.Join(os.Getenv("PROGRAMDATA"), configFolder, configFileName)),
 		}
 
 	default:

--- a/internal/mock/path.go
+++ b/internal/mock/path.go
@@ -2,25 +2,26 @@ package mock
 
 import (
 	"fmt"
-	"path"
+	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 // Path returns the absolute path to the specified mock file.
 func Path(filename string) string {
-
 	// determine the path of this file during runtime
 	_, thisfile, _, _ := runtime.Caller(0)
 
+	breadcrumbs := []string{
+		filepath.Dir(thisfile),
+		filepath.Clean("../../mocks"),
+		filepath.Clean(filename),
+	}
+
 	// compute the config path
-	file, err := filepath.Abs(
-		path.Join(
-			filepath.Dir(thisfile),
-			"../../mocks",
-			filename,
-		),
-	)
+	combinedBreadcrumbs := strings.Join(breadcrumbs, string(os.PathSeparator))
+	file, err := filepath.Abs(combinedBreadcrumbs)
 	if err != nil {
 		panic(fmt.Errorf("failed to resolve config path: %v", err))
 	}

--- a/internal/sheet/sheet_test.go
+++ b/internal/sheet/sheet_test.go
@@ -2,6 +2,8 @@ package sheet
 
 import (
 	"reflect"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/cheat/cheat/internal/mock"
@@ -34,9 +36,15 @@ func TestSheetSuccess(t *testing.T) {
 		)
 	}
 
+	gotText := sheet.Text
+	if runtime.GOOS == "windows" {
+		// If we're on windows with \r\n line separators \r needs to go
+		gotText = strings.ReplaceAll(gotText, "\r", "")
+	}
+
 	wantText := "# To foo the bar:\n  foo bar\n"
-	if sheet.Text != wantText {
-		t.Errorf("failed to init text: want: %s, got: %s", wantText, sheet.Text)
+	if gotText != wantText {
+		t.Errorf("failed to init text: want: %s, got: %s", wantText, gotText)
 	}
 
 	// NB: tags should sort alphabetically


### PR DESCRIPTION
This PR attempts to improve the way `cheat` handles default paths on different operating systems.

- Adds two new functions `config.PreferredFolderPath()` and `config.PreferredConfigPath()` that return OS-specific values
- Converts `configs/conf.yml` and `cmd/cheat/docopt.txt`  to templates that will be used to generate OS-specific values
- Improves the message returned if no config file is found
- Refactors `mock.Path(...)` to enable running tests on Windows

### More details

`config.PreferredConfigPath()` returns

 - _On all operating systems_: the contents of `CHEAT_CONFIG_PATH` if defined
 - _macOS_: `~/Library/Application Support/cheat/conf.yml`
 - _Linux_: `${XDG_CONFIG_HOME}/cheat/conf.yml` if `XDG_CONFIG_HOME` is defined; otherwise `~/.config/cheat/conf.yml`
 - _Windows_: `$env:APPDATA\cheat\conf.yml`

`config.PreferredFolderPath()` is basically `filepath.Dir(config.PreferredConfigPath())`

Using these we can generate OS-specific `cheatpaths` for the `--init` command and also provide OS-specific instructions to initialize a config file. These instructions will be used in the usage examples but also in the error message returned if no configuration file is found.

_macOS_
```bash
mkdir -p ~/Library/Application\ Support/cheat && cheat --init > ~/Library/Application\ Support/cheat/conf.yml
```

_Linux_
```bash
mkdir -p ~/.config/cheat && cheat --init > ~/.config/cheat/conf.yml
```


_Windows_
```powershell
md -Force "$env:APPDATA\cheat" | Out-Null; cheat.exe --init > "$env:APPDATA\cheat\conf.yml"
```

