### PR TITLE
fix: colorization errors

### DIFF
--- a/cmd/cheat/cmd_search.go
+++ b/cmd/cheat/cmd_search.go
@@ -38,12 +38,6 @@ func cmdSearch(opts map[string]interface{}, conf config.Config) {
 	// sort the cheatsheets alphabetically, and search for matches
 	for _, sheet := range sheets.Sort(consolidated) {
 
-		// colorize output?
-		colorize := false
-		if conf.Colorize == true || opts["--colorize"] == true {
-			colorize = true
-		}
-
 		// assume that we want to perform a case-insensitive search for <phrase>
 		pattern := "(?i)" + phrase
 
@@ -60,7 +54,7 @@ func cmdSearch(opts map[string]interface{}, conf config.Config) {
 		}
 
 		// search the sheet
-		matches := sheet.Search(reg, colorize)
+		matches := sheet.Search(reg, conf.Color(opts))
 
 		// display the results
 		if len(matches) > 0 {

--- a/cmd/cheat/cmd_view.go
+++ b/cmd/cheat/cmd_view.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/alecthomas/chroma/quick"
-	"github.com/mattn/go-isatty"
 
 	"github.com/cheat/cheat/internal/config"
 	"github.com/cheat/cheat/internal/sheets"
@@ -44,20 +43,7 @@ func cmdView(opts map[string]interface{}, conf config.Config) {
 		os.Exit(0)
 	}
 
-	// apply colorization if so configured ...
-	colorize := conf.Colorize
-
-	// ... or if --colorized were passed ...
-	if opts["--colorize"] == true {
-		colorize = true
-	}
-
-	// ... unless we're outputting to a non-TTY
-	if !isatty.IsTerminal(os.Stdout.Fd()) && !isatty.IsCygwinTerminal(os.Stdout.Fd()) {
-		colorize = false
-	}
-
-	if !colorize {
+	if !conf.Color(opts) {
 		fmt.Print(sheet.Text)
 		os.Exit(0)
 	}

--- a/cmd/cheat/main.go
+++ b/cmd/cheat/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cheat/cheat/internal/config"
 )
 
-const version = "3.2.0"
+const version = "3.2.1"
 
 func main() {
 

--- a/internal/config/color.go
+++ b/internal/config/color.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"os"
+
+	"github.com/mattn/go-isatty"
+)
+
+// Color indicates whether colorization should be applied to the output
+func (c *Config) Color(opts map[string]interface{}) bool {
+
+	// default to the colorization specified in the configs...
+	colorize := c.Colorize
+
+	// ... however, only apply colorization if we're writing to a tty...
+	if !isatty.IsTerminal(os.Stdout.Fd()) && !isatty.IsCygwinTerminal(os.Stdout.Fd()) {
+		colorize = false
+	}
+
+	// ... *unless* the --colorize flag was passed
+	if opts["--colorize"] == true {
+		colorize = true
+	}
+
+	return colorize
+}


### PR DESCRIPTION
- Corrects an error with `--search`. Previously, `--search` was not
  aware of whether it was outputted to a TTY, and would apply colorization
  at all times. This resulted in unwanted behavior when, for example,
  piping search results into a paginator.

- Corrects an error with `--color`. Previously, `--color` would be
  ignored if output was being written to a non-TTY. This made it
  impossible, for example, to `cheat tar --color | less -R`, as
  colorization would always be stripped. The behavior of `--color` has
  been modified such that it now behaves similarly to `--color=always` in
  other applications.