### PR TITLE
3.3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,10 @@ language: go
 
 go:
   - 1.13.x
+
+env:
+  - GO111MODULE=on
+
+install: true
+
+script: make ci

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ clean: $(dist_dir)
 ## distclean: removes the tags file
 .PHONY: distclean
 distclean:
-	$(RM) ./tags
+	$(RM) tags
 
 ## setup: installs revive (linter) and scc (sloc tool)
 .PHONY: setup
@@ -106,7 +106,7 @@ sloc:
 ## tags: builds a tags file
 .PHONY: tags
 tags:
-	$(CTAGS) -R . --exclude=./vendor
+	$(CTAGS) -R . --exclude=vendor
 
 ## vendor: downloads, tidies, and verifies dependencies
 .PHONY: vendor

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ SORT   := sort
 ZIP    := zip -m
 
 # build flags
-BUILD_FLAGS  := -ldflags="-s -w" -mod vendor
+BUILD_FLAGS  := -ldflags="-s -w" -mod vendor -trimpath
 GOBIN        :=
 
 # release binaries
@@ -39,6 +39,10 @@ build: $(dist_dir)
 ## build-release: builds release executables
 .PHONY: build-release
 build-release: $(releases)
+
+## ci: builds a "release" executable for the current architecture (used in ci)
+.PHONY: ci
+ci: | setup prepare build
 
 # cheat-darwin-amd64
 $(dist_dir)/cheat-darwin-amd64: prepare

--- a/cmd/cheat/main.go
+++ b/cmd/cheat/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cheat/cheat/internal/config"
 )
 
-const version = "3.3.1"
+const version = "3.3.2"
 
 func main() {
 


### PR DESCRIPTION
- makes trivial `Makefile` changes
- passes `-trimpath` to build tasks
- bumps version to `3.3.2`