### PR TITLE
fix: README and Makefil

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ releases :=                        \
 
 ## build: builds an executable for your architecture
 .PHONY: build
-build: $(dist_dir) clean generate
+build: $(dist_dir) clean vendor generate
 	$(GO) build $(BUILD_FLAGS) -o $(dist_dir)/cheat $(cmd_dir)
 
 ## build-release: builds release executables
@@ -85,7 +85,7 @@ generate:
 
 ## install: builds and installs cheat on your PATH
 .PHONY: install
-install:
+install: build
 	$(GO) install $(BUILD_FLAGS) $(GOBIN) $(cmd_dir) 
 
 ## clean: removes compiled executables

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ cheat -p personal -t networking --regex -s '(?:[0-9]{1,3}\.){3}[0-9]{1,3}'
 Advanced Usage
 --------------
 Shell autocompletion is currently available for the `bash` and `fish` shells.
-Copy the relevant [completion script][completion-scripts] into the appropriate
+Copy the relevant [completion script][completions] into the appropriate
 directory on your filesystem to enable autocompletion. (This directory will
 vary depending on operating system and shell specifics.)
 
@@ -206,6 +206,6 @@ integration:
 2. Set an envvar: `export CHEAT_USE_FZF=true`
 
 [Releases]:    https://github.com/cheat/cheat/releases
-[bash]:        https://github.com/cheat/cheat/blob/master/scripts/fzf.bash
 [cheatsheets]: https://github.com/cheat/cheatsheets
+[completions]: https://github.com/cheat/cheat/tree/master/scripts
 [fzf]:         https://github.com/junegunn/fzf


### PR DESCRIPTION
- Fixes a typo in the `README`
- Fixes `install` and `build` targets in `Makefile`.