### PR TITLE
add complete script for zsh.

### DIFF
--- a/scripts/cheat.zsh
+++ b/scripts/cheat.zsh
@@ -1,0 +1,58 @@
+#compdef cheat
+
+local -a cheats
+cheats=()
+
+_cheat_complete_cheatsheets()
+{
+  cheats=("${(f)$(cheat -l -t personal | tail -n +2 | cut -d' ' -f1)}")
+  _describe -t cheats 'cheats' cheats
+}
+
+_cheat_complete_tags()
+{
+  taglist=("${(f)$(cheat -T)}")
+  _describe -t taglist 'taglist' taglist
+}
+
+_cheat_complete_paths()
+{
+  pathlist=("${(f)$(cheat -d | cut -d':' -f1)}")
+  _describe -t pathlist 'pathlist' pathlist
+}
+
+_cheat() {
+
+  _arguments -C \
+    '(--init)--init[Write a default config file to stdout]: :->none' \
+    '(-c --colorize)'{-c,--colorize}'[Colorize output]: :->none' \
+    '(-d --directories)'{-d,--directories}'[List cheatsheet directories]: :->none' \
+    '(-e --edit)'{-e,--edit}'[Edit <sheet>]: :->full' \
+    '(-l --list)'{-l,--list}'[List cheatsheets]: :->full' \
+    '(-p --path)'{-p,--path}'[Return only sheets found on path <name>]: :->pathlist' \
+    '(-r --regex)'{-r,--regex}'[Treat search <phrase> as a regex]: :->none' \
+    '(-s --search)'{-s,--search}'[Search cheatsheets for <phrase>]: :->none' \
+    '(-t --tag)'{-t,--tag}'[Return only sheets matching <tag>]: :->taglist' \
+    '(-T --tags)'{-T,--tags}'[List all tags in use]: :->none' \
+    '(-v --version)'{-v,--version}'[Print the version number]: :->none' \
+    '(--rm)--rm[Remove (delete) <sheet>]: :->full' \
+
+  case $state in
+    (none)
+      ;;
+    (full)
+      _cheat_complete_cheatsheets
+      ;;
+    (taglist)
+      _cheat_complete_tags
+      ;;
+    (pathlist)
+      _cheat_complete_paths
+      ;;
+    (*)
+      _cheat_complete_cheatsheets
+      ;;
+  esac
+}
+
+_cheat

--- a/scripts/cheat.zsh
+++ b/scripts/cheat.zsh
@@ -1,7 +1,6 @@
 #compdef cheat
 
-local -a cheats
-cheats=()
+local cheats taglist pathlist
 
 _cheat_complete_cheatsheets()
 {


### PR DESCRIPTION
I've wrote a completion script for zsh inspired by the compltion script for bash in cheat repo.

And I recommand people who use this script combine @Aloxaf 's zsh plugin -- [Aloxaf/fzf-tab: Replace zsh's default completion selection menu with fzf!](https://github.com/Aloxaf/fzf-tab) to make fzf completion great again for zsh. As zsh now report `LBUFFER` can't change by completion widget, and `fzf-tab` make completion widget on zsh work again.

Below gif shows the result when the zsh completion script works with the help of `fzf-tab`.


![fzf-tab](https://user-images.githubusercontent.com/9500049/78338245-fc96c300-75c4-11ea-8e44-9a94ebaa039b.gif)