### PR TITLE
Improve zsh completion

### DIFF
--- a/scripts/cheat.zsh
+++ b/scripts/cheat.zsh
@@ -2,9 +2,15 @@
 
 local cheats taglist pathlist
 
-_cheat_complete_cheatsheets()
+_cheat_complete_personal_cheatsheets()
 {
   cheats=("${(f)$(cheat -l -t personal | tail -n +2 | cut -d' ' -f1)}")
+  _describe -t cheats 'cheats' cheats
+}
+
+_cheat_complete_full_cheatsheets()
+{
+  cheats=("${(f)$(cheat -l | tail -n +2 | cut -d' ' -f1)}")
   _describe -t cheats 'cheats' cheats
 }
 
@@ -26,7 +32,7 @@ _cheat() {
     '(--init)--init[Write a default config file to stdout]: :->none' \
     '(-c --colorize)'{-c,--colorize}'[Colorize output]: :->none' \
     '(-d --directories)'{-d,--directories}'[List cheatsheet directories]: :->none' \
-    '(-e --edit)'{-e,--edit}'[Edit <sheet>]: :->full' \
+    '(-e --edit)'{-e,--edit}'[Edit <sheet>]: :->personal' \
     '(-l --list)'{-l,--list}'[List cheatsheets]: :->full' \
     '(-p --path)'{-p,--path}'[Return only sheets found on path <name>]: :->pathlist' \
     '(-r --regex)'{-r,--regex}'[Treat search <phrase> as a regex]: :->none' \
@@ -34,13 +40,17 @@ _cheat() {
     '(-t --tag)'{-t,--tag}'[Return only sheets matching <tag>]: :->taglist' \
     '(-T --tags)'{-T,--tags}'[List all tags in use]: :->none' \
     '(-v --version)'{-v,--version}'[Print the version number]: :->none' \
-    '(--rm)--rm[Remove (delete) <sheet>]: :->full' \
+    '(--rm)--rm[Remove (delete) <sheet>]: :->personal' \
+    '(-)*: :->full'
 
   case $state in
     (none)
       ;;
     (full)
-      _cheat_complete_cheatsheets
+      _cheat_complete_full_cheatsheets
+      ;;
+    (personal)
+      _cheat_complete_personal_cheatsheets
       ;;
     (taglist)
       _cheat_complete_tags
@@ -49,7 +59,6 @@ _cheat() {
       _cheat_complete_paths
       ;;
     (*)
-      _cheat_complete_cheatsheets
       ;;
   esac
 }


### PR DESCRIPTION
We cannot complete sheet name with current implementation. This patch adds new state transfer when current word does not start with `-`(dash) then completes all sheets.

### original
No completions are listed when input `t` and TAB

![before](https://user-images.githubusercontent.com/554281/79058861-14013a80-7cae-11ea-95cc-7ece59621c5b.png)

### with this patch
Completions which starts with `t` are listed when input `t` and TAB

![after](https://user-images.githubusercontent.com/554281/79058866-182d5800-7cae-11ea-9475-a2a94953c9f2.png)
