### PR TITLE
cheat should exit with a failure code if the cheatsheet isn't found

### DIFF
--- a/cmd/cheat/cmd_view.go
+++ b/cmd/cheat/cmd_view.go
@@ -38,7 +38,7 @@ func cmdView(opts map[string]interface{}, conf config.Config) {
 	sheet, ok := consolidated[cheatsheet]
 	if !ok {
 		fmt.Printf("No cheatsheet found for '%s'.\n", cheatsheet)
-		os.Exit(0)
+		os.Exit(1)
 	}
 
 	// apply colorization if requested


### PR DESCRIPTION
If there's no cheatsheet for the requested command, `cheat` should exit with a non-zero exit code.