### PR TITLE
Add config path for linux

### DIFF
--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -37,11 +37,20 @@ func Paths(
 		}
 
 		// if `XDG_CONFIG_HOME` is not set, search the user's home directory
-		paths = append(paths, []string{
-			path.Join(home, ".config/cheat/conf.yml"),
-			path.Join(home, ".cheat/conf.yml"),
-		}...)
-
+		if sys == "linux" {
+			// if we are on the linux then also check the location which is
+			// conforming to the file system hiearchy standard
+			paths = append(paths, []string{
+				path.Join(home, ".config/cheat/conf.yml"),
+				path.Join(home, ".cheat/conf.yml"),
+				"/etc/cheat/conf.yml",
+			}...)
+		} else {
+			paths = append(paths, []string{
+				path.Join(home, ".config/cheat/conf.yml"),
+				path.Join(home, ".cheat/conf.yml"),
+			}...)
+		}
 		return paths, nil
 	case "windows":
 		return []string{

--- a/internal/config/paths_test.go
+++ b/internal/config/paths_test.go
@@ -34,13 +34,22 @@ func TestValidatePathsNix(t *testing.T) {
 			t.Errorf("paths returned an error: %v", err)
 		}
 
+		want := []string{}
 		// specify the expected output
-		want := []string{
-			"/home/bar/cheat/conf.yml",
-			"/home/foo/.config/cheat/conf.yml",
-			"/home/foo/.cheat/conf.yml",
+		if os == "linux" {
+			want = []string{
+				"/home/bar/cheat/conf.yml",
+				"/home/foo/.config/cheat/conf.yml",
+				"/home/foo/.cheat/conf.yml",
+				"/etc/cheat/conf.yml",
+			}
+		} else {
+			want = []string{
+				"/home/bar/cheat/conf.yml",
+				"/home/foo/.config/cheat/conf.yml",
+				"/home/foo/.cheat/conf.yml",
+			}
 		}
-
 		// assert that output matches expectations
 		if !reflect.DeepEqual(paths, want) {
 			t.Errorf(
@@ -77,10 +86,19 @@ func TestValidatePathsNixNoXDG(t *testing.T) {
 			t.Errorf("paths returned an error: %v", err)
 		}
 
+		want := []string{}
 		// specify the expected output
-		want := []string{
-			"/home/foo/.config/cheat/conf.yml",
-			"/home/foo/.cheat/conf.yml",
+		if os == "linux" {
+			want = []string{
+				"/home/foo/.config/cheat/conf.yml",
+				"/home/foo/.cheat/conf.yml",
+				"/etc/cheat/conf.yml",
+			}
+		} else {
+			want = []string{
+				"/home/foo/.config/cheat/conf.yml",
+				"/home/foo/.cheat/conf.yml",
+			}
 		}
 
 		// assert that output matches expectations


### PR DESCRIPTION
- Add path which conforms to the file system hiearchy standard
/etc/cheat/conf.yml

Hi @chrisallenlane ,
I made time to rebase cheat in Fedora and i found out that i'm now unable to make it work out of the box as before. This pullrequest adds one path to the paths from which cheat attempts to read configuration and that is "/etc/cheat/conf.yml". This change takes effect only on linux and it is conforming to the filesystem hierarchy standard [0].

Looking forward for your opinion:)

[0] - https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard