### PR TITLE
fix(config): add /etc/cheat config path

### DIFF
--- a/cmd/cheat/main.go
+++ b/cmd/cheat/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/cheat/cheat/internal/installer"
 )
 
-const version = "4.0.1"
+const version = "4.0.2"
 
 func main() {
 

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -36,10 +36,10 @@ func Paths(
 			paths = append(paths, path.Join(xdgpath, "/cheat/conf.yml"))
 		}
 
-		// if `XDG_CONFIG_HOME` is not set, search the user's home directory
 		paths = append(paths, []string{
 			path.Join(home, ".config/cheat/conf.yml"),
 			path.Join(home, ".cheat/conf.yml"),
+			"/etc/cheat/conf.yml",
 		}...)
 
 		return paths, nil

--- a/internal/config/paths_test.go
+++ b/internal/config/paths_test.go
@@ -39,6 +39,7 @@ func TestValidatePathsNix(t *testing.T) {
 			"/home/bar/cheat/conf.yml",
 			"/home/foo/.config/cheat/conf.yml",
 			"/home/foo/.cheat/conf.yml",
+			"/etc/cheat/conf.yml",
 		}
 
 		// assert that output matches expectations
@@ -81,6 +82,7 @@ func TestValidatePathsNixNoXDG(t *testing.T) {
 		want := []string{
 			"/home/foo/.config/cheat/conf.yml",
 			"/home/foo/.cheat/conf.yml",
+			"/etc/cheat/conf.yml",
 		}
 
 		// assert that output matches expectations


### PR DESCRIPTION
Add `/etc/cheat/conf.yml` to default config paths. See #568 for context.