### PR TITLE
support `cheat <tag>/cheatpath` grammar

### DIFF
--- a/cmd/cheat/cmd_view_test.go
+++ b/cmd/cheat/cmd_view_test.go
@@ -1,0 +1,34 @@
+package main
+
+import "testing"
+
+type PathTestRes struct {
+	tag       string
+	cheatPath string
+}
+
+type PathTest struct {
+	path   string
+	result PathTestRes
+}
+
+var dirtests = []PathTest{
+	{"abc", PathTestRes{"abc", ""}},
+	{"abc/def", PathTestRes{"abc", "def"}},
+	{"a/b/.x", PathTestRes{"a", "b/.x"}},
+	{"a/b/c.", PathTestRes{"a", "b/c."}},
+	{"a/b/c.x", PathTestRes{"a", "b/c.x"}},
+	{"a/b/b/a", PathTestRes{"a", "b/b/a"}},
+	{"a/b/c/b", PathTestRes{"a", "b/c/b"}},
+
+	{"b/b", PathTestRes{"b", "b"}},
+	{"a/b/b", PathTestRes{"a", "b/b"}},
+}
+
+func TestSplitTagAndPath(t *testing.T) {
+	for _, test := range dirtests {
+		if tag, cheatPath := splitTagAndPath(test.path); tag != test.result.tag || cheatPath != test.result.cheatPath {
+			t.Errorf("splitTagAndPath (%q) = %q, %q, want %q, %q", test.path, tag, cheatPath, test.result.tag, test.result.cheatPath)
+		}
+	}
+}


### PR DESCRIPTION
```
# same as `cheat -t community git`
cheat community/git  
```
If `--tag` is given, it will not try to parse tag any more.

If tranditional search failed, it trys to parse the cheatpath as tag+cheatpath

I believe this grammar is cleaner than `-t tag`