### PR TITLE
feat: implement `cheat -t` shorthand

### DIFF
--- a/cmd/cheat/main.go
+++ b/cmd/cheat/main.go
@@ -185,6 +185,9 @@ func main() {
 	case opts["<cheatsheet>"] != nil:
 		cmd = cmdView
 
+	case opts["--tag"] != nil && opts["--tag"].(string) != "":
+		cmd = cmdList
+
 	default:
 		fmt.Println(usage())
 		os.Exit(0)

--- a/cmd/cheat/main.go
+++ b/cmd/cheat/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/cheat/cheat/internal/installer"
 )
 
-const version = "4.0.3"
+const version = "4.1.0"
 
 func main() {
 


### PR DESCRIPTION
Support `cheat -t <tag>` as a shorthand for `cheat -l -t <tag>` (#581).