### PR TITLE
Removed the sentence where it tells there are no dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ tar -cjvf '/path/to/foo.tgz' '/path/to/foo/'
 
 Installing
 ----------
-`cheat` has no dependencies. To install it, download the executable from the
+To install it, download the executable from the
 [releases][] page and place it on your `PATH`.
 
 Alternatively, if you have [go][] installed, you may install `cheat` using `go


### PR DESCRIPTION
https://src.fedoraproject.org/rpms/cheat/blob/rawhide/f/cheat.spec currently lists 8 dependencies if we exclude the whole Go runtime.