### PR TITLE
Fix Windows

### DIFF
--- a/build/embed.go
+++ b/build/embed.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 // This script embeds `docopt.txt and `conf.yml` into the binary during at
@@ -5,13 +6,11 @@
 
 package main
 
-
 import (
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
-	"path"
 	"path/filepath"
 )
 
@@ -52,10 +51,10 @@ func main() {
 	for _, file := range files {
 
 		// delete the outfile
-		os.Remove(path.Join(root, file.Out))
+		os.Remove(filepath.Join(root, file.Out))
 
 		// read the static template
-		bytes, err := ioutil.ReadFile(path.Join(root, file.In))
+		bytes, err := ioutil.ReadFile(filepath.Join(root, file.In))
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -64,7 +63,7 @@ func main() {
 		data := template(file.Method, string(bytes))
 
 		// write the file to the specified outpath
-		spath := path.Join(root, file.Out)
+		spath := filepath.Join(root, file.Out)
 		err = ioutil.WriteFile(spath, []byte(data), 0644)
 		if err != nil {
 			log.Fatal(err)

--- a/cmd/cheat/main.go
+++ b/cmd/cheat/main.go
@@ -45,6 +45,9 @@ func main() {
 	envvars := map[string]string{}
 	for _, e := range os.Environ() {
 		pair := strings.SplitN(e, "=", 2)
+		if runtime.GOOS == "windows" {
+			pair[0] = strings.ToUpper(pair[0])
+		}
 		envvars[pair[0]] = pair[1]
 	}
 

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 
 	"github.com/mitchellh/go-homedir"
 )
@@ -33,20 +33,20 @@ func Paths(
 
 		// don't include the `XDG_CONFIG_HOME` path if that envvar is not set
 		if xdgpath, ok := envvars["XDG_CONFIG_HOME"]; ok {
-			paths = append(paths, path.Join(xdgpath, "/cheat/conf.yml"))
+			paths = append(paths, filepath.Join(xdgpath, "/cheat/conf.yml"))
 		}
 
 		paths = append(paths, []string{
-			path.Join(home, ".config/cheat/conf.yml"),
-			path.Join(home, ".cheat/conf.yml"),
+			filepath.Join(home, ".config/cheat/conf.yml"),
+			filepath.Join(home, ".cheat/conf.yml"),
 			"/etc/cheat/conf.yml",
 		}...)
 
 		return paths, nil
 	case "windows":
 		return []string{
-			path.Join(envvars["APPDATA"], "/cheat/conf.yml"),
-			path.Join(envvars["PROGRAMDATA"], "/cheat/conf.yml"),
+			filepath.Join(envvars["APPDATA"], "/cheat/conf.yml"),
+			filepath.Join(envvars["PROGRAMDATA"], "/cheat/conf.yml"),
 		}, nil
 	default:
 		return []string{}, fmt.Errorf("unsupported os: %s", sys)

--- a/internal/installer/prompt.go
+++ b/internal/installer/prompt.go
@@ -23,7 +23,7 @@ func Prompt(prompt string, def bool) (bool, error) {
 	}
 
 	// normalize the answer
-	ans = strings.ToLower(strings.TrimRight(ans, "\n"))
+	ans = strings.ToLower(strings.TrimSpace(ans))
 
 	// return the appropriate response
 	switch ans {


### PR DESCRIPTION
* path must not be used for physical paths. (use path/filepath instead)
* Windows does not treat environment variable's name case-sensitive.
* Prompt always contain `\r`