### PR TITLE
fix(Paths): Android support

### DIFF
--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -28,7 +28,7 @@ func Paths(
 	}
 
 	switch sys {
-	case "darwin", "linux", "freebsd":
+	case "android", "darwin", "linux", "freebsd":
 		paths := []string{}
 
 		// don't include the `XDG_CONFIG_HOME` path if that envvar is not set

--- a/internal/config/paths_test.go
+++ b/internal/config/paths_test.go
@@ -21,6 +21,7 @@ func TestValidatePathsNix(t *testing.T) {
 
 	// specify the platforms to test
 	oses := []string{
+		"android",
 		"darwin",
 		"freebsd",
 		"linux",


### PR DESCRIPTION
Add `"android"` to the explicit whitelist of supported operating
systems.  This may resolve incompatibilities with certain Android
environments.