### PR TITLE
~[Installing] go get install deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Installing
 [releases][] page and place it on your `PATH`.
 
 Alternatively, if you have [go][] installed, you may install `cheat` using `go
-get`:
+get` (or [`go
+install` if your go version is >1.6][gogetdeprecation]) :
 
 ```sh
 go get -u github.com/cheat/cheat/cmd/cheat
@@ -228,3 +229,4 @@ Additionally, `cheat` supports enhanced autocompletion via integration with
 [completions]: https://github.com/cheat/cheat/tree/master/scripts
 [fzf]:         https://github.com/junegunn/fzf
 [go]:          https://golang.org
+[gogetdeprecation]:       https://go.dev/doc/go-get-install-deprecation


### PR DESCRIPTION
Deprecation of 'go get' for installing executables

@see https://go.dev/doc/go-get-install-deprecation and https://github.com/golang/go/issues/40276

close #649

An other TODO will be to make the deprecation in the CICD and Makefile :
- https://github.com/cheat/cheat/blob/7fe0fed32bfbe15a2647d04d31e3cb7f860deeaa/.github/workflows/build.yml#L24
- https://github.com/cheat/cheat/blob/768d55e5d4738131cdcb097004d5de45e762db4e/Makefile#L118
- https://github.com/cheat/cheat/blob/768d55e5d4738131cdcb097004d5de45e762db4e/Makefile#L143

But I got no time to make tests around today...
... Let's me know if you want me to do this simple change or if your preference goes to keep the CI/CD well maintained by yourself :thinking: 