### PR TITLE
Build/CI corrections

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16
+        go-version: 1.18
 
     - name: Set up Revive (linter)
       run: go get -u github.com/boyter/scc github.com/mgechev/revive
@@ -41,7 +41,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16
+        go-version: 1.18
 
     - name: Set up Revive (linter)
       run: go get -u github.com/boyter/scc github.com/mgechev/revive


### PR DESCRIPTION
- Use `go install` instead of `go get` now that the behavior of the latter has changed. (#651 )
- Use Go 1.18 in the CI pipeline.

