### PR TITLE
4.3.1

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -9,13 +9,13 @@ On Unix-like systems, you may simply paste the following snippet into your termi
 
 ```sh
 cd /tmp \
-  && wget https://github.com/cheat/cheat/releases/download/4.3.0/cheat-linux-amd64.gz \
+  && wget https://github.com/cheat/cheat/releases/download/4.3.1/cheat-linux-amd64.gz \
   && gunzip cheat-linux-amd64.gz \
   && chmod +x cheat-linux-amd64 \
   && sudo mv cheat-linux-amd64 /usr/local/bin/cheat
 ```
 
-You may need to need to change the version number (`4.3.0`) and the archive
+You may need to need to change the version number (`4.3.1`) and the archive
 (`cheat-linux-amd64.gz`) depending on your platform.
 
 See the [releases page][releases] for a list of supported platforms.

--- a/cmd/cheat/main.go
+++ b/cmd/cheat/main.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cheat/cheat/internal/installer"
 )
 
-const version = "4.3.0"
+const version = "4.3.1"
 
 func main() {
 

--- a/cmd/cheat/str_config.go
+++ b/cmd/cheat/str_config.go
@@ -9,7 +9,7 @@ import (
 func configs() string {
 	return strings.TrimSpace(`---
 # The editor to use with 'cheat -e <sheet>'. Defaults to $EDITOR or $VISUAL.
-# editor: vim
+editor: EDITOR_PATH
 
 # Should 'cheat' always colorize output?
 colorize: false

--- a/cmd/cheat/str_config.go
+++ b/cmd/cheat/str_config.go
@@ -17,11 +17,11 @@ colorize: false
 # Which 'chroma' colorscheme should be applied to the output?
 # Options are available here:
 #   https://github.com/alecthomas/chroma/tree/master/styles
-# style: monokai
+style: monokai
 
 # Which 'chroma' "formatter" should be applied?
 # One of: "terminal", "terminal256", "terminal16m"
-formatter: terminal
+formatter: terminal256
 
 # Through which pager should output be piped?
 # 'less -FRX' is recommended on Unix systems
@@ -41,7 +41,6 @@ pager: PAGER_PATH
 # commands. So, if you want to view the 'tar' cheatsheet that is tagged as
 # 'community' rather than your own, you can use: cheat tar -t community
 cheatpaths:
-
   # Paths that come earlier are considered to be the most "global", and will
   # thus be overridden by more local cheatsheets. That being the case, you
   # should probably list community cheatsheets first.

--- a/configs/conf.yml
+++ b/configs/conf.yml
@@ -8,11 +8,11 @@ colorize: false
 # Which 'chroma' colorscheme should be applied to the output?
 # Options are available here:
 #   https://github.com/alecthomas/chroma/tree/master/styles
-# style: monokai
+style: monokai
 
 # Which 'chroma' "formatter" should be applied?
 # One of: "terminal", "terminal256", "terminal16m"
-formatter: terminal
+formatter: terminal256
 
 # Through which pager should output be piped?
 # 'less -FRX' is recommended on Unix systems
@@ -32,7 +32,6 @@ pager: PAGER_PATH
 # commands. So, if you want to view the 'tar' cheatsheet that is tagged as
 # 'community' rather than your own, you can use: cheat tar -t community
 cheatpaths:
-
   # Paths that come earlier are considered to be the most "global", and will
   # thus be overridden by more local cheatsheets. That being the case, you
   # should probably list community cheatsheets first.

--- a/configs/conf.yml
+++ b/configs/conf.yml
@@ -1,6 +1,6 @@
 ---
 # The editor to use with 'cheat -e <sheet>'. Defaults to $EDITOR or $VISUAL.
-# editor: vim
+editor: EDITOR_PATH
 
 # Should 'cheat' always colorize output?
 colorize: false

--- a/internal/config/editor.go
+++ b/internal/config/editor.go
@@ -15,11 +15,22 @@ func Editor() (string, error) {
 		return "notepad", nil
 	}
 
-	// look for `nano` on the `PATH`
+	// look for `nano` and `vim` on the `PATH`
+	def, _ := exec.LookPath("editor") // default `editor` wrapper
 	nano, _ := exec.LookPath("nano")
+	vim, _ := exec.LookPath("vim")
 
-	// search for `$VISUAL`, `$EDITOR`, and then `nano`, in that order
-	for _, editor := range []string{os.Getenv("VISUAL"), os.Getenv("EDITOR"), nano} {
+	// set editor priority
+	editors := []string{
+		os.Getenv("VISUAL"),
+		os.Getenv("EDITOR"),
+		def,
+		nano,
+		vim,
+	}
+
+	// return the first editor that was found per the priority above
+	for _, editor := range editors {
 		if editor != "" {
 			return editor, nil
 		}

--- a/internal/config/pager.go
+++ b/internal/config/pager.go
@@ -3,10 +3,16 @@ package config
 import (
 	"os"
 	"os/exec"
+	"runtime"
 )
 
 // Pager attempts to locate a pager that's appropriate for the environment.
 func Pager() string {
+
+	// default to `more` on Windows
+	if runtime.GOOS == "windows" {
+		return "more"
+	}
 
 	// if $PAGER is set, return the corresponding pager
 	if os.Getenv("PAGER") != "" {

--- a/internal/installer/run.go
+++ b/internal/installer/run.go
@@ -20,10 +20,17 @@ func Run(configs string, confpath string) error {
 	community := filepath.Join(confdir, "cheatsheets", "community")
 	personal := filepath.Join(confdir, "cheatsheets", "personal")
 
-	// template the above paths into the default configs
+	// set default cheatpaths
 	configs = strings.Replace(configs, "COMMUNITY_PATH", community, -1)
 	configs = strings.Replace(configs, "PERSONAL_PATH", personal, -1)
+
+	// locate and set a default pager
 	configs = strings.Replace(configs, "PAGER_PATH", config.Pager(), -1)
+
+	// locate and set a default editor
+	if editor, err := config.Editor(); err == nil {
+		configs = strings.Replace(configs, "EDITOR_PATH", editor, -1)
+	}
 
 	// prompt the user to download the community cheatsheets
 	yes, err := Prompt(


### PR DESCRIPTION
- fix(Sheets): cheatsheets in hidden directories (#690)
- fix: no colorization on default install (#687)
- feat(installer): set default `editor`
- fix(installer): always use `more` pager on Windows
- chore: bump version to `4.3.1`
