### PR TITLE
Fix ZSH autocompletion

### DIFF
--- a/scripts/cheat.zsh
+++ b/scripts/cheat.zsh
@@ -40,7 +40,8 @@ _cheat() {
     '(-t --tag)'{-t,--tag}'[Return only sheets matching <tag>]: :->taglist' \
     '(-T --tags)'{-T,--tags}'[List all tags in use]: :->none' \
     '(-v --version)'{-v,--version}'[Print the version number]: :->none' \
-    '(--rm)--rm[Remove (delete) <sheet>]: :->personal' 
+    '(--rm)--rm[Remove (delete) <sheet>]: :->personal' \
+    '(-)*: :->full'
 
   case $state in
     (none)


### PR DESCRIPTION
this close: #632

this revert the changes about deletion of `'(-)*: :->full'`.

I think keep the '(-)*: :->full' is a right behavior.
if we remove this line, we cannot get completion about all cheat files...


related:

- https://github.com/cheat/cheat/issues/632
- https://github.com/cheat/cheat/pull/629