### PR TITLE
lookup XDG_CONFIG_HOME in openbsd

### DIFF
--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -28,7 +28,7 @@ func Paths(
 	}
 
 	switch sys {
-	case "android", "darwin", "linux", "freebsd":
+	case "android", "darwin", "linux", "freebsd", "openbsd":
 		paths := []string{}
 
 		// don't include the `XDG_CONFIG_HOME` path if that envvar is not set


### PR DESCRIPTION
openbsd is needlessly left out from this  XDG_CONFIG_HOME check which caused the program to exit prematurely. go supports openbsd so there isn't any sensible reason to exclude it.