### PR TITLE
Change module path to `v4` per `go` conventions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cheat/cheat
+module github.com/cheat/cheat/v4
 
 go 1.19
 


### PR DESCRIPTION
For major versions > 1, the `go` convention is that the module path should have a suffix with the major version.

Since the published version is currently `4.4.2`, that means it should be `/v4`

More details here: 
* https://github.com/cheat/cheat/issues/652#issuecomment-1031924526