### PR TITLE
fix: zsh completion definition

### DIFF
--- a/scripts/cheat.zsh
+++ b/scripts/cheat.zsh
@@ -62,4 +62,4 @@ _cheat() {
   esac
 }
 
-compdef _cheat cheat
+_cheat "$@"


### PR DESCRIPTION
Cheat's upstream provides a *non-standard* zsh-completion script. It has confused lots of package managers (like Homebrew, Nixpkgs and aur). After installed, `cheat.zsh` will be added to `/usr/share/zsh/site-functions` which is included in `fpath`, and zsh will autoload the file to define the completion function. Therefore, no `compdef` is needed. If the last line is `compdef _cheat cheat`, the file must be sourced explicitly.

[This commit](https://github.com/cheat/cheat/commit/018bce7ad550fa1de8b131500c7e1d360a32b0e8) causes the problem.
