### PR TITLE
chore: use install instead of get

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ distclean:
 ## setup: install revive (linter) and scc (sloc tool)
 .PHONY: setup
 setup:
-	GO111MODULE=off $(GO) get -u github.com/boyter/scc github.com/mgechev/revive
+	GO111MODULE=off $(GO) install github.com/boyter/scc github.com/mgechev/revive
 
 ## sloc: count "semantic lines of code"
 .PHONY: sloc


### PR DESCRIPTION
The `go get` command is no longer supported. 