### PR TITLE
Added a link to the wiki for integration with fzf

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,9 @@ Additionally, `cheat` supports enhanced autocompletion via integration with
 1. Ensure that `fzf` is available on your `$PATH`
 2. Set an envvar: `export CHEAT_USE_FZF=true`
 
+See the [Enable-fzf-Integration](https://github.com/cheat/cheat/wiki/Enable-fzf-Integration) wiki page for an example of integrating with fzf with cheat for autocompletions in oh-my-zsh 
+
+
 [INSTALLING.md]: INSTALLING.md
 [Releases]:      https://github.com/cheat/cheat/releases
 [cheatsheets]:   https://github.com/cheat/cheatsheets


### PR DESCRIPTION
In regards to https://github.com/cheat/cheat/issues/594, I added a [page on integrating with fzf for autocompletions](https://github.com/dinakazakevich/cheat/wiki/Enable-fzf-Integration). Unfortunately, the wiki won't allow PR for non-contributors. Please review it and let me know if I/you can add it.